### PR TITLE
增加禁用植物生成的选项

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -82,6 +82,10 @@ public class PlantsListener implements Listener {
 
     @EventHandler
     public void onGenerate(ChunkPopulateEvent e) {
+        if (!cfg.getBoolean("options.auto-generate-plants")) {
+            return;
+        }
+
         final World world = e.getWorld();
 
         if (!Slimefun.getWorldSettingsService().isWorldEnabled(world)) {

--- a/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
+++ b/src/main/java/io/github/thebusybiscuit/exoticgarden/listeners/PlantsListener.java
@@ -82,7 +82,7 @@ public class PlantsListener implements Listener {
 
     @EventHandler
     public void onGenerate(ChunkPopulateEvent e) {
-        if (!cfg.getBoolean("options.auto-generate-plants")) {
+        if (!cfg.getOrSetDefault("options.auto-generate-plants", true)) {
             return;
         }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,9 +1,10 @@
-grass-drops: []
+grass-drops: [ ]
 world-blacklist:
-- world_nether
-- world_the_end
+  - world_nether
+  - world_the_end
 chances:
   TREE: 22
   BUSH: 16
 options:
   auto-update: false
+  auto-generate-plants: true


### PR DESCRIPTION
增加这个选项是因为，服务器经常需要加载和卸载一些世界。每次都修改黑名单，然后重启服务器，实在是太麻烦了。